### PR TITLE
docs: add ADR-81 selector facts

### DIFF
--- a/.doctrine/project.json
+++ b/.doctrine/project.json
@@ -5,6 +5,7 @@
     "name": "Effect Dart",
     "lifecycle": "active",
     "layer": "foundation",
+    "policyPool": "library-package",
     "summary": "Dart effect-system package with typed effects, typed errors, dependency context, runtime execution, concurrency, and functional data types.",
     "goals": [
       "Provide the public effect_dart Dart package export.",
@@ -87,6 +88,7 @@
   },
   "delivery": {
     "ciModel": "none",
+    "deployable": false,
     "requiredContexts": [],
     "deployPath": "No repo-local GitHub CI or package release workflow is present. Package publication path is not declared in this repository baseline.",
     "productionProof": "Dart format, dart analyze --fatal-infos, dart test, example/API readback, and package registry readback for published versions.",


### PR DESCRIPTION
## Summary
- Add `project.policyPool: library-package` and `delivery.deployable: false` to the project manifest.
- Make ADR-81 selector projection complete for this non-deployable foundation library.

## Validation
- `python3 -m json.tool .doctrine/project.json`
- `python3 /Users/kyle/.doctrine/scripts/project-control-plane-audit.py --local . --fail-on-drift --json` -> `PRESENT`
- `python3 /Users/kyle/.doctrine/scripts/project-control-plane-audit.py --repo SylphxAI/effect --ref codex/adr81-selector-facts --fail-on-drift --json` -> `PRESENT`
- `python3 /Users/kyle/.doctrine/scripts/repo-selector-value-projection.py --repo SylphxAI/effect --ref codex/adr81-selector-facts --fail-on-blocked --json` -> `READY`
- `python3 /Users/kyle/.doctrine/scripts/package-release-conformance-audit.py --repo SylphxAI/effect --ref codex/adr81-selector-facts --json` -> `OUT_OF_SCOPE`
- `git diff --check`